### PR TITLE
update dvc.yaml remotes

### DIFF
--- a/pipeline_b_detect/i/dvc.yaml
+++ b/pipeline_b_detect/i/dvc.yaml
@@ -40,9 +40,7 @@ stages:
     outs:
       - pipeline_b_detect/${target}/${model_dir}/model_pipeline_b_detect_${target}.file:
           cache: false
-    metrics:
-      - pipeline_b_detect/${target}/results/metrics.json
-    plots:
+      - pipeline_b_detect/${target}/results/metrics.json:
+          remote: remote-i
       - pipeline_b_detect/${target}/results/plots/metrics/accuracy.tsv:
-          x: step	
-          y: accuracy
+          remote: remote-i

--- a/pipeline_b_detect/j/dvc.yaml
+++ b/pipeline_b_detect/j/dvc.yaml
@@ -40,9 +40,7 @@ stages:
     outs:
       - pipeline_b_detect/${target}/${model_dir}/model_pipeline_b_detect_${target}.file:
           cache: false
-    metrics:
-      - pipeline_b_detect/${target}/results/metrics.json
-    plots:
+      - pipeline_b_detect/${target}/results/metrics.json:
+          remote: remote-j
       - pipeline_b_detect/${target}/results/plots/metrics/accuracy.tsv:
-          x: step	
-          y: accuracy
+          remote: remote-j


### PR DESCRIPTION
@mnrozhkov PTAL. In `dvc.yaml`, you can set the `remote:` field for the outputs to control which remote they use. I also made one other minor change to stop using stage-level metrics and plots. They are redundant since dvc is saving the same info in the root `dvc.yaml` file here, and we generally are trying to steer users away from this pattern and simplifying to only using generic `outs` in stages.